### PR TITLE
findCheapestSpot updates cheapestFound variable

### DIFF
--- a/scripts/volcano_mining.ash
+++ b/scripts/volcano_mining.ash
@@ -583,6 +583,7 @@ int findCheapestSpot(Spot[int] listOfSpots) {
 	foreach spotNdx in listOfSpots {
 		if ((listOfSpots[spotNdx].costToGetTo < cheapestFound) && !listOfSpots[spotNdx].mined) {
 			cheapestSpot = listOfSpots[spotNdx];
+			cheapestFound = listOfSpots[spotNdx].costToGetTo;
 			foundViableSpot = true;
 		}
 	}


### PR DESCRIPTION
the "findCheapestSpot" method uses the cheapestFound variable to keep track of the cheapest possible spot to mine.
Unfortunately, this script does not update the variable properly.

the old behavior will just mine to the nearest available interesting spot.
in lazy mode, the old behavior would tend to skip entries on the second row, if there was another inaccessible entry on the second row.