### PR TITLE
Fix lazy mining

### DIFF
--- a/scripts/volcano_mining.ash
+++ b/scripts/volcano_mining.ash
@@ -579,6 +579,9 @@ void mineSingleSpot() {
 int findCheapestSpot(Spot[int] listOfSpots) {
 	int cheapestFound = 10000;
 	boolean foundViableSpot = false;
+	if (count(listOfSpots) == 0) {
+		return -1;
+	}
 	Spot cheapestSpot = listOfSpots[0];
 	foreach spotNdx in listOfSpots {
 		if ((listOfSpots[spotNdx].costToGetTo < cheapestFound) && !listOfSpots[spotNdx].mined) {


### PR DESCRIPTION
Currently `findCheapestSpot` will actually *insert* a fake cheapest spot if the list is empty.  This breaks lazy mining.